### PR TITLE
feat: Using Ubuntu Trusty Tahr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # `docker run -ti -v ~/projects:/projects sparkbox/tinder:latest`
 ######################
 
-FROM ubuntu:latest
+FROM ubuntu:trusty
 
 MAINTAINER Ryan Cromwell <ryan@heysparkbox.com>
 


### PR DESCRIPTION
Basing this on the most recent LTS version of Ubuntu is probably better
than simply grabbing the latest release. Trusty Tahr is the latest
Ubuntu LTS and is supported through October 2019.
